### PR TITLE
Add ten new custom ASCII visuals

### DIFF
--- a/src/components/MathVisual.tsx
+++ b/src/components/MathVisual.tsx
@@ -76,6 +76,16 @@ import RadialMeshFlower from './custom-visuals/RadialMeshFlower';
 import CanyonUndulatingWalls from './custom-visuals/CanyonUndulatingWalls';
 import WaveInterferenceV5 from './custom-visuals/WaveInterferenceV5';
 import EffortlessParticles from './custom-visuals/EffortlessParticles';
+import QuantumLatticeBloom from './custom-visuals/QuantumLatticeBloom';
+import FractalWaterfall from './custom-visuals/FractalWaterfall';
+import PulsatingYinYangNebula from './custom-visuals/PulsatingYinYangNebula';
+import NonEuclideanRippleMaze from './custom-visuals/NonEuclideanRippleMaze';
+import FibonacciSpiralGarden from './custom-visuals/FibonacciSpiralGarden';
+import MobiusFlowTunnel from './custom-visuals/MobiusFlowTunnel';
+import StarfieldEntanglement from './custom-visuals/StarfieldEntanglement';
+import HyperbolicMirrorSequence from './custom-visuals/HyperbolicMirrorSequence';
+import EmergentTreeOfVoid from './custom-visuals/EmergentTreeOfVoid';
+import PenroseTriangleIllusion from './custom-visuals/PenroseTriangleIllusion';
 
 export const devMode = true;
 
@@ -223,6 +233,16 @@ export const customVisuals = [
   CanyonUndulatingWalls,
   WaveInterferenceV5,
   EffortlessParticles,
+  QuantumLatticeBloom,
+  FractalWaterfall,
+  PulsatingYinYangNebula,
+  NonEuclideanRippleMaze,
+  FibonacciSpiralGarden,
+  MobiusFlowTunnel,
+  StarfieldEntanglement,
+  HyperbolicMirrorSequence,
+  EmergentTreeOfVoid,
+  PenroseTriangleIllusion,
 ];
 
 

--- a/src/components/Snapshot.tsx
+++ b/src/components/Snapshot.tsx
@@ -76,6 +76,16 @@ import RadialMeshFlower from './custom-visuals/RadialMeshFlower';
 import CanyonUndulatingWalls from './custom-visuals/CanyonUndulatingWalls';
 import WaveInterferenceV5 from './custom-visuals/WaveInterferenceV5';
 import EffortlessParticles from './custom-visuals/EffortlessParticles';
+import QuantumLatticeBloom from './custom-visuals/QuantumLatticeBloom';
+import FractalWaterfall from './custom-visuals/FractalWaterfall';
+import PulsatingYinYangNebula from './custom-visuals/PulsatingYinYangNebula';
+import NonEuclideanRippleMaze from './custom-visuals/NonEuclideanRippleMaze';
+import FibonacciSpiralGarden from './custom-visuals/FibonacciSpiralGarden';
+import MobiusFlowTunnel from './custom-visuals/MobiusFlowTunnel';
+import StarfieldEntanglement from './custom-visuals/StarfieldEntanglement';
+import HyperbolicMirrorSequence from './custom-visuals/HyperbolicMirrorSequence';
+import EmergentTreeOfVoid from './custom-visuals/EmergentTreeOfVoid';
+import PenroseTriangleIllusion from './custom-visuals/PenroseTriangleIllusion';
 
 const customVisuals = {
   1: MoireMandalaPattern,
@@ -154,6 +164,16 @@ const customVisuals = {
   74: CanyonUndulatingWalls,
   75: WaveInterferenceV5,
   76: EffortlessParticles,
+  77: QuantumLatticeBloom,
+  78: FractalWaterfall,
+  79: PulsatingYinYangNebula,
+  80: NonEuclideanRippleMaze,
+  81: FibonacciSpiralGarden,
+  82: MobiusFlowTunnel,
+  83: StarfieldEntanglement,
+  84: HyperbolicMirrorSequence,
+  85: EmergentTreeOfVoid,
+  86: PenroseTriangleIllusion,
 };
 
 const Snapshot = () => {

--- a/src/components/custom-visuals/EmergentTreeOfVoid.tsx
+++ b/src/components/custom-visuals/EmergentTreeOfVoid.tsx
@@ -1,0 +1,51 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: creation and dissolution
+const EmergentTreeOfVoid: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const grow = (x: number, y: number, len: number, angle: number, depth: number) => {
+      if (depth <= 0 || len < 2) return;
+      const nx = x + Math.cos(angle) * len;
+      const ny = y + Math.sin(angle) * len;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(nx, ny);
+      ctx.strokeStyle = `rgba(50,50,50,${0.1 + 0.2 * depth})`;
+      ctx.stroke();
+      const sway = Math.sin(time + depth) * 0.2;
+      grow(nx, ny, len * 0.7, angle + 0.5 + sway, depth - 1);
+      grow(nx, ny, len * 0.7, angle - 0.5 + sway, depth - 1);
+    };
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      ctx.lineWidth = 1;
+      grow(width / 2, height, height * 0.25, -Math.PI / 2, 6);
+      time += 0.02;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default EmergentTreeOfVoid;

--- a/src/components/custom-visuals/FibonacciSpiralGarden.tsx
+++ b/src/components/custom-visuals/FibonacciSpiralGarden.tsx
@@ -1,0 +1,52 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: natural order, blooming spirals
+const FibonacciSpiralGarden: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let count = 0;
+    let time = 0;
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height / 2;
+      const golden = Math.PI * (3 - Math.sqrt(5));
+      const max = 800;
+      count = (count + 2) % max;
+
+      for (let i = 0; i < count; i++) {
+        const angle = i * golden;
+        const r = Math.sqrt(i) * 6;
+        const x = cx + Math.cos(angle) * r;
+        const y = cy + Math.sin(angle) * r;
+        const alpha = i / max;
+        ctx.beginPath();
+        ctx.arc(x, y, 3, 0, Math.PI * 2);
+        ctx.fillStyle = `rgba(50,50,50,${alpha})`;
+        ctx.fill();
+      }
+      time += 0.02;
+      animationId = requestAnimationFrame(animate);
+    };
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default FibonacciSpiralGarden;

--- a/src/components/custom-visuals/FractalWaterfall.tsx
+++ b/src/components/custom-visuals/FractalWaterfall.tsx
@@ -1,0 +1,52 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: infinite depth, recursive flow, gentle cascade
+const FractalWaterfall: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const drawFall = (x: number, y: number, w: number, h: number, depth: number) => {
+      if (depth <= 0) return;
+      const segments = 20;
+      ctx.beginPath();
+      for (let i = 0; i <= segments; i++) {
+        const t = i / segments;
+        const nx = x + w * (t - 0.5) + Math.sin(time + t * 10 + depth) * 10 / depth;
+        const ny = y + h * t;
+        if (i === 0) ctx.moveTo(nx, ny); else ctx.lineTo(nx, ny);
+      }
+      ctx.strokeStyle = `rgba(50,50,50,${0.2 + 0.6 / depth})`;
+      ctx.stroke();
+      drawFall(x - w * 0.15, y + h * 0.5, w * 0.7, h * 0.6, depth - 1);
+      drawFall(x + w * 0.15, y + h * 0.5, w * 0.7, h * 0.6, depth - 1);
+    };
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      drawFall(width / 2, 0, width * 0.4, height, 4);
+      time += 0.02;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default FractalWaterfall;

--- a/src/components/custom-visuals/HyperbolicMirrorSequence.tsx
+++ b/src/components/custom-visuals/HyperbolicMirrorSequence.tsx
@@ -1,0 +1,46 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: infinite reflections, curved space
+const HyperbolicMirrorSequence: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height * 0.9;
+      const mirrors = 20;
+      for (let i = 0; i < mirrors; i++) {
+        const t = i / mirrors;
+        const r = (Math.exp(t * 3) - 1) / (Math.exp(3) - 1) * width;
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, Math.PI, Math.PI * 2);
+        ctx.strokeStyle = `rgba(50,50,50,${0.4 - t * 0.4})`;
+        ctx.stroke();
+      }
+      time += 0.01;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default HyperbolicMirrorSequence;

--- a/src/components/custom-visuals/MobiusFlowTunnel.tsx
+++ b/src/components/custom-visuals/MobiusFlowTunnel.tsx
@@ -1,0 +1,52 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: one-sided journey, endless loop
+const MobiusFlowTunnel: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height / 2;
+      const rings = 30;
+      for (let i = 0; i < rings; i++) {
+        const t = i / rings;
+        const r = t * Math.min(width, height) * 0.5;
+        const twist = Math.sin(time + t * Math.PI) * 30;
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, r, r * 0.4, time + t * Math.PI, 0, Math.PI * 2);
+        ctx.strokeStyle = `rgba(50,50,50,${0.5 - t * 0.5})`;
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(cx - r, cy);
+        ctx.lineTo(cx + r, cy + twist);
+        ctx.strokeStyle = `rgba(80,80,80,${0.3 - t * 0.3})`;
+        ctx.stroke();
+      }
+      time += 0.01;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default MobiusFlowTunnel;

--- a/src/components/custom-visuals/NonEuclideanRippleMaze.tsx
+++ b/src/components/custom-visuals/NonEuclideanRippleMaze.tsx
@@ -1,0 +1,59 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: warped paths, shifting geometry
+const NonEuclideanRippleMaze: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const grid = 20;
+    const gaps = new Set<string>();
+    for (let i = 0; i < grid * grid; i++) {
+      if (Math.random() < 0.3) {
+        const x = i % grid;
+        const y = Math.floor(i / grid);
+        gaps.add(`${x},${y}`);
+      }
+    }
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const cellW = width / grid;
+      const cellH = height / grid;
+
+      for (let i = 0; i < grid; i++) {
+        for (let j = 0; j < grid; j++) {
+          if (gaps.has(`${i},${j}`)) continue;
+          const x = i * cellW;
+          const y = j * cellH;
+          const warp = Math.sin((x + y) * 0.02 + time) * 5;
+          ctx.strokeStyle = 'rgba(50,50,50,0.3)';
+          ctx.strokeRect(x + warp, y - warp, cellW, cellH);
+        }
+      }
+
+      time += 0.02;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default NonEuclideanRippleMaze;

--- a/src/components/custom-visuals/PenroseTriangleIllusion.tsx
+++ b/src/components/custom-visuals/PenroseTriangleIllusion.tsx
@@ -1,0 +1,57 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: paradox, shifting perspective
+const PenroseTriangleIllusion: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const drawBeam = (angle: number) => {
+      const cx = width / 2;
+      const cy = height / 2;
+      const r = Math.min(width, height) * 0.3;
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.rotate(angle);
+      ctx.beginPath();
+      ctx.moveTo(-r, -r * 0.2);
+      ctx.lineTo(r, -r * 0.2);
+      ctx.lineTo(r, r * 0.2);
+      ctx.lineTo(-r, r * 0.2);
+      ctx.closePath();
+      ctx.fillStyle = 'rgba(50,50,50,0.4)';
+      ctx.fill();
+      ctx.restore();
+    };
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const rot = time * 0.2;
+      drawBeam(rot);
+      drawBeam(rot + (2 * Math.PI) / 3);
+      drawBeam(rot + (4 * Math.PI) / 3);
+      time += 0.01;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default PenroseTriangleIllusion;

--- a/src/components/custom-visuals/PulsatingYinYangNebula.tsx
+++ b/src/components/custom-visuals/PulsatingYinYangNebula.tsx
@@ -1,0 +1,53 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: duality, harmony, cosmic breath
+const PulsatingYinYangNebula: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const particles = Array.from({ length: 800 }, (_, i) => ({ angle: (i / 800) * Math.PI * 2 }));
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height / 2;
+      const baseR = Math.min(width, height) * 0.35;
+      const breathe = baseR * 0.15 * Math.sin(time * 0.5);
+
+      particles.forEach((p, idx) => {
+        const dir = idx % 2 === 0 ? 1 : -1;
+        const r = baseR + breathe * dir;
+        const angle = p.angle + dir * time * 0.2;
+        const x = cx + Math.cos(angle) * r;
+        const y = cy + Math.sin(angle) * r;
+        ctx.beginPath();
+        ctx.arc(x, y, 2, 0, Math.PI * 2);
+        ctx.fillStyle = idx % 2 === 0 ? 'rgba(50,50,50,0.5)' : 'rgba(120,120,120,0.5)';
+        ctx.fill();
+      });
+      time += 0.02;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default PulsatingYinYangNebula;

--- a/src/components/custom-visuals/QuantumLatticeBloom.tsx
+++ b/src/components/custom-visuals/QuantumLatticeBloom.tsx
@@ -1,0 +1,53 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: hidden order, quantum fluctuations, discrete expansion
+const QuantumLatticeBloom: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+
+      const cols = 24;
+      const rows = 24;
+      for (let i = 0; i < cols; i++) {
+        for (let j = 0; j < rows; j++) {
+          const cx = (i + 0.5) * width / cols;
+          const cy = (j + 0.5) * height / rows;
+          const phase = Math.sin(time + i * 0.3 + j * 0.3);
+          const r = 2 + phase * 2;
+          ctx.beginPath();
+          ctx.arc(cx, cy, r, 0, Math.PI * 2);
+          ctx.fillStyle = `rgba(50,50,50,${0.4 + 0.4 * phase})`;
+          ctx.fill();
+        }
+      }
+      time += 0.04;
+      animationId = requestAnimationFrame(animate);
+    };
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div
+      className="flex justify-center items-center shadow-lg rounded-lg"
+      style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}
+    >
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default QuantumLatticeBloom;

--- a/src/components/custom-visuals/StarfieldEntanglement.tsx
+++ b/src/components/custom-visuals/StarfieldEntanglement.tsx
@@ -1,0 +1,51 @@
+import React, { useRef, useEffect } from 'react';
+import { VisualProps } from '../../types';
+
+// Themes: mirrored cosmos, instantaneous connection
+const StarfieldEntanglement: React.FC<VisualProps> = ({ width, height }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    canvas.width = width;
+    canvas.height = height;
+    let time = 0;
+
+    const stars = Array.from({ length: 120 }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      speed: 0.2 + Math.random() * 0.4
+    }));
+
+    const animate = () => {
+      ctx.fillStyle = '#F0EEE6';
+      ctx.fillRect(0, 0, width, height);
+      stars.forEach((s, idx) => {
+        const px = (s.x + time * s.speed) % width;
+        const py = (s.y + time * s.speed * 0.5) % height;
+        const mx = width - px;
+        const my = height - py;
+        const alpha = 0.3 + 0.7 * Math.abs(Math.sin(time * 0.1 + idx));
+        ctx.fillStyle = `rgba(50,50,50,${alpha})`;
+        ctx.fillRect(px, py, 2, 2);
+        ctx.fillRect(mx, my, 2, 2);
+      });
+      time += 0.5;
+      animationId = requestAnimationFrame(animate);
+    };
+
+    let animationId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(animationId);
+  }, [width, height]);
+
+  return (
+    <div className="flex justify-center items-center shadow-lg rounded-lg" style={{ width: `${width}px`, height: `${height}px`, backgroundColor: '#F0EEE6' }}>
+      <canvas ref={canvasRef} className="max-w-full max-h-full" />
+    </div>
+  );
+};
+
+export default StarfieldEntanglement;


### PR DESCRIPTION
## Summary
- implement ten original animated canvas components
- register new visuals in MathVisual and Snapshot

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c588bd65ac8323998b9cdcfde3cdc9